### PR TITLE
Update activesupport dependency settings in gemspec

### DIFF
--- a/warden-cognito.gemspec
+++ b/warden-cognito.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_dependency 'activesupport', ['>= 6.0', '< 8.0']
+  spec.add_dependency 'activesupport', ['>= 6.0', '< 8.1']
   spec.add_dependency 'aws-sdk-cognitoidentityprovider', '~> 1.47'
   spec.add_dependency 'dry-auto_inject', '~> 0.6'
   spec.add_dependency 'dry-configurable', '~> 0.9'


### PR DESCRIPTION
I mentioned this in the [linear issue](https://linear.app/invibe/issue/INV-3721/update-warden-cognito-to-work-with-rails-8) but as far as I can see, ActiveSupport is only used in one place in this app and it's a class that isn't affected by the rails 8 changes.

I noticed that last branch was merged into the `update-jwt` branch instead of master so this PR also targets that branch. Not sure if we want to actually merge into master or not. Either way, once this is merged in I'll update the gemfile in the snap repo.