### PR TITLE
Update cognito to work with rails 8.3

### DIFF
--- a/warden-cognito.gemspec
+++ b/warden-cognito.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_dependency 'activesupport', ['>= 6.0', '< 8.1']
+  spec.add_dependency 'activesupport', ['>= 6.0', '< 8.4']
   spec.add_dependency 'aws-sdk-cognitoidentityprovider', '~> 1.47'
   spec.add_dependency 'dry-auto_inject', '~> 0.6'
   spec.add_dependency 'dry-configurable', '~> 0.9'


### PR DESCRIPTION
This is required to update rails on the snap side. `active-support` is only used in one place in this repo and it's not affected by this minor version upgrade